### PR TITLE
Organizations.list now takes a parm hash

### DIFF
--- a/lib/megam/api/version.rb
+++ b/lib/megam/api/version.rb
@@ -1,5 +1,5 @@
 module Megam
   class API
-    VERSION = "0.38"
+    VERSION = "0.39"
   end
 end

--- a/lib/megam/core/organizations.rb
+++ b/lib/megam/core/organizations.rb
@@ -76,71 +76,68 @@ end
       index_hash
     end
 
-def to_json(*a)
-  for_json.to_json(*a)
-end
+    def to_json(*a)
+      for_json.to_json(*a)
+    end
 
-def for_json
-  result = {
-    "id" => id,
-    "name" => name,
-    "accounts_id" => accounts_id,
-    "created_at" => created_at
-  }
-  result
-end
+    def for_json
+      result = {
+        "id" => id,
+        "name" => name,
+        "accounts_id" => accounts_id,
+        "created_at" => created_at
+      }
+      result
+    end
 
-# Create a Megam::Organization from JSON (used by the backgroud job workers)
-def self.json_create(o)
-  org = new
-  org.id(o["id"]) if o.has_key?("id")
-  org.name(o["name"]) if o.has_key?("name")
-  org.accounts_id(o["accounts_id"]) if o.has_key?("accounts_id")
-  org.created_at(o["created_at"]) if o.has_key?("created_at")
-  org
-end
+    # Create a Megam::Organization from JSON (used by the backgroud job workers)
+    def self.json_create(o)
+      org = new
+      org.id(o["id"]) if o.has_key?("id")
+      org.name(o["name"]) if o.has_key?("name")
+      org.accounts_id(o["accounts_id"]) if o.has_key?("accounts_id")
+      org.created_at(o["created_at"]) if o.has_key?("created_at")
+      org
+    end
 
-def self.from_hash(o)
-  org = self.new(o[:email], o[:api_key])
-  org.from_hash(o)
-  org
-end
+    def self.from_hash(o)
+      org = self.new(o[:email], o[:api_key])
+      org.from_hash(o)
+      org
+    end
 
-def from_hash(o)
-  @id        = o[:id] if o.has_key?(:id)
-  @name     = o[:name] if o.has_key?(:name)
-  @accounts_id = o[:accounts_id] if o.has_key?(:accounts_id)
-  @created_at = o[:created_at] if o.has_key?(:created_at)
-  self
-end
+    def from_hash(o)
+      @id        = o[:id] if o.has_key?(:id)
+      @name     = o[:name] if o.has_key?(:name)
+      @accounts_id = o[:accounts_id] if o.has_key?(:accounts_id)
+      @created_at = o[:created_at] if o.has_key?(:created_at)
+      self
+    end
 
-def self.create(o)
-  org = from_hash(o)
-  org.create
-end
+    def self.create(o)
+      org = from_hash(o)
+      org.create
+    end
 
-# Load a organization by email_p
-def self.show(email,api_key=nil)
-  org = self.new(email, api_key)
-  org.megam_rest.get_organizations(email)
-end
+    # Load a organization by email_p
+    def self.show(o)
+      org = from_hash(o)
+      org.megam_rest.get_organizations(email)
+    end
 
- def self.list(tmp_email=nil, tmp_api_key=nil)
-    org = self.new(tmp_email,tmp_api_key)
+    def self.list(o)
+      org = from_hash(o)
       org.megam_rest.get_organizations
- end
- 
- 
-    
-def create
-      megam_rest.post_organizations(to_hash)
-end
-
-def to_s
-      Megam::Stuff.styled_hash(to_hash)
     end
 
 
-  end
+    def create
+      megam_rest.post_organizations(to_hash)
+    end
 
+    def to_s
+      Megam::Stuff.styled_hash(to_hash)
+    end
+
+  end
 end


### PR DESCRIPTION
@morpheyesh @thomasalrin @rajthilakmca  Please read this.
- When ever you touch api, make sure it take a `hash` as opposed to just variables. 
### Bad

``` ruby
def create (email, api_key = nil
end
```
### Good

``` ruby
def create(parms)
parms[:email] = super_cool
parms[:api_key] = super_easy
end
```
- Also I noticed that the `accounts` api is named as **account\* whereas most of the api are named in **plural** 
