### PR TITLE
Liberate api from nilavu.yml bondage

### DIFF
--- a/lib/megam/api.rb
+++ b/lib/megam/api.rb
@@ -139,11 +139,6 @@ module Megam
     # 3. Upon merge of the options, the api_key, email as available in the @options is deleted.
     def initialize(options={})
       @options = OPTIONS.merge(options)
-      if File.exist?("#{ENV['MEGAM_HOME']}/nilavu.yml")
-          @common = YAML.load_file("#{ENV['MEGAM_HOME']}/nilavu.yml")                  #COMMON YML
-          @options[:host] = "#{@common["api"]["host"]}"
-          @options[:scheme] = "#{@common["api"]["scheme"]}"
-        end
       @api_key = @options.delete(:api_key) || ENV['MEGAM_API_KEY']
       @email = @options.delete(:email)
       raise ArgumentError, "You must specify [:email, :api_key]" if @email.nil? || @api_key.nil?
@@ -232,24 +227,7 @@ module Megam
         X_Megam_HMAC => encoded_api_header[:hmac],
         X_Megam_DATE => encoded_api_header[:date],
       }).merge(@options[:headers])
-
-
-      if @options[:scheme] == "https"
-
-      if !File.exist?(File.expand_path(File.join("#{ENV['MEGAM_HOME']}", "#{@common["api"]["pub_key"]}")))
-        text.warn("Certificate file does not exist. SSL_VERIFY_PEER set as false")
-        Excon.defaults[:ssl_verify_peer] = false
-        @options[:scheme] == "http"
-      elsif !File.exist?(File.expand_path(File.join(File.dirname(__FILE__), "..", "certs", "cacert.pem")))
-        text.warn("Certificate file does not exist. SSL_VERIFY_PEER set as false")
-        Excon.defaults[:ssl_verify_peer] = false
-        @options[:scheme] == "http"
-      else
-        Megam::Log.debug("Certificate found")
-        Excon.defaults[:ssl_verify_peer] = true
-        Excon.defaults[:ssl_ca_file] = File.expand_path(File.join("#{ENV['MEGAM_HOME']}", "#{@common["api"]["pub_key"]}")) || File.expand_path(File.join(File.dirname(__FILE__), "..", "certs", "cacert.pem"))
-      end
-      end
+  
 
       Megam::Log.debug("HTTP Request Data:")
       Megam::Log.debug("> HTTP #{@options[:scheme]}://#{@options[:host]}")

--- a/lib/megam/api/version.rb
+++ b/lib/megam/api/version.rb
@@ -1,5 +1,5 @@
 module Megam
   class API
-    VERSION = "0.55"
+    VERSION = "0.56"
   end
 end


### PR DESCRIPTION
`:host` was pulled from the nilavu.yml file. This is bad and hence removed it. Any client which wants to use `megam_api` ruby gem will pass the `:host` it will connect to.

From https://github.com/megamsys/nilavu.git we use `stick_keys` method to send it.
